### PR TITLE
update build-deps to work on rpi

### DIFF
--- a/rpi/Makefile
+++ b/rpi/Makefile
@@ -15,7 +15,7 @@ build-rpi:
 	env GOOS=linux GOARCH=arm go build -o ${out} ${package}
 
 install-pico-deps:
-	sudo apt-get install libusb-dev
+	sudo apt-get install libusb-1.0-0.dev
 
 install-pico: install-pico-deps
 	mkdir -p tools
@@ -23,6 +23,7 @@ install-pico: install-pico-deps
 	tar xvzf ${pico_software_name}.tar.gz -C tools/
 	rm ${pico_software_name}.tar.gz
 	cd tools/${pico_software_name}-${pico_software_version}/client && make
+	sudo cp tools/${pico_software_name}-${pico_software_version}/client/usbtenkiget /usr/local/bin/
 
 install:
 	go install ${package}

--- a/rpi/sensor/pico/pico.go
+++ b/rpi/sensor/pico/pico.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	processName = "usbtenkiget"
+	processName = "/usr/local/bin/usbtenkiget"
 	/*
 		the -i flag takes comma-separated sensor channels.
 		00 - co2


### PR DESCRIPTION
- Apparently, rasbian OS requires a specific dev version to work.
- Also update install step to move binary to /usr/local/bin and update `exec.Command` to have the correct path.
  - files that lie in the `/usr/local/bin/` folder can be run from wherever on the computer (for example running `git status` in the terminal works this way).