### PR TITLE
update log message

### DIFF
--- a/rpi/main.go
+++ b/rpi/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	err := pico.Boot()
 	if err != nil {
-		log.Fatal("could not boot pico sensor software: %w", err)
+		log.Fatalf("could not boot pico sensor software: %v", err)
 	}
 
 	fmt.Println("Hello Pico!")


### PR DESCRIPTION
`log.Fatal` does not expect any extra parameters to print
`log.Fatalf` (the last f stands for format) lets me format variables in the string that is logged.