### PR TITLE
add deploy support for api

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,13 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude locally vendored dependencies.
+vendor/
+
+# Exclude "build-time" ignore files.
+.dockerignore
+.gcloudignore
+
+# Exclude git history and configuration.
+.gitignore

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.16-buster as builder
+
+WORKDIR /app
+
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o server ./cmd/server
+
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/server /app/server
+COPY ./internal/db/migrations/ /internal/db/migrations/
+
+# Run the web service on container startup.
+CMD ["/app/server"]

--- a/api/Makefile
+++ b/api/Makefile
@@ -5,3 +5,7 @@ develop: run-database
 
 run-database:
 	docker compose up -d
+
+deploy:
+	gcloud builds submit --tag gcr.io/senzr-313218/senzr
+	gcloud run services update senzr-api --image=gcr.io/senzr-313218/senzr:latest --region=europe-west1


### PR DESCRIPTION
Run `make deploy` in the api folder to deploy the API to Cloud Run.

Improvements: Move the deployment to a CI/CD pipeline (Prefer Cloud Build in Google Cloud)