### PR TITLE
add latest co2 entry endpoint

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	PORT = 3000
+	Port     = 3000
+	BasePath = "/api"
+	V1       = "/v1"
 )
 
 func main() {
@@ -18,17 +20,23 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	database := db.Db{}
+
 	// controllers
-	cs := rpi.Controller{}
+	rpiServer := rpi.Server{Db: &database}
 
 	// routes
 	r := gin.Default()
-	r.GET("/helloworld", cs.HelloWorld)
+	v1 := r.Group(BasePath + V1)
+	{
+		v1.GET("/helloworld", rpiServer.HelloWorld)
+		v1.GET("/co2/latest", rpiServer.GetLatestCarbonDioxideEntry)
+	}
 
 	// start app
-	err := r.Run(fmt.Sprintf(":%v", PORT))
+	err := r.Run(fmt.Sprintf(":%v", Port))
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	log.Printf("server successfully started on port %v", PORT)
+	log.Printf("server successfully started on port %v", Port)
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -19,4 +19,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/api v0.45.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/api/internal/db/transaction.go
+++ b/api/internal/db/transaction.go
@@ -7,44 +7,72 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-type Transaction struct {
-	tx *sqlx.Tx
+type Db struct{}
+
+type Database interface {
+	BeginTransaction() (_ Transaction, err error)
+}
+
+var _ Database = &Db{}
+
+type Transaction interface {
+	Get(dest interface{}, query string, args ...interface{}) error
+	Select(dest interface{}, query string, args ...interface{}) error
+	NamedExec(query string, arg interface{}) (sql.Result, error)
+	Query(query string) (*sqlx.Rows, error)
+	Commit() error
+}
+
+type Tx struct {
+	Tx *sqlx.Tx
 	db *sqlx.DB
 }
 
-func (t *Transaction) Get(dest interface{}, query string) error {
-	err := t.tx.Get(dest, query)
+var _ Transaction = &Tx{}
+
+func (t *Tx) Get(dest interface{}, query string, args ...interface{}) error {
+	var err error
+	if len(args) != 0 {
+		err = t.Tx.Get(&dest, query, args)
+	} else {
+		err = t.Tx.Get(&dest, query)
+	}
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (t *Transaction) Select(dest interface{}, query string) error {
-	err := t.tx.Select(dest, query)
+func (t *Tx) Select(dest interface{}, query string, args ...interface{}) error {
+	var err error
+	if len(args) != 0 {
+		err = t.Tx.Select(dest, query, args)
+	} else {
+		err = t.Tx.Select(dest, query)
+	}
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (t *Transaction) NamedExec(query string, arg interface{}) (sql.Result, error) {
-	return t.tx.NamedExec(query, arg)
+func (t *Tx) NamedExec(query string, arg interface{}) (sql.Result, error) {
+	return t.Tx.NamedExec(query, arg)
 }
 
-func (t *Transaction) Query(query string) (*sqlx.Rows, error) {
-	rows, err := t.tx.Queryx(query)
+func (t *Tx) Query(query string) (*sqlx.Rows, error) {
+	rows, err := t.Tx.Queryx(query)
 	if err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (t *Transaction) Commit() error {
+func (t *Tx) Commit() error {
 	if t.db == nil {
 		return fmt.Errorf("connection is already closed")
 	}
-	err := t.tx.Commit()
+	err := t.Tx.Commit()
 	if err != nil {
 		return err
 	}
@@ -52,12 +80,12 @@ func (t *Transaction) Commit() error {
 	if err != nil {
 		return err
 	}
-	t.tx = nil
+	t.Tx = nil
 	t.db = nil
 	return nil
 }
 
-func BeginTransaction() (_ *Transaction, err error) {
+func (d *Db) BeginTransaction() (_ Transaction, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("transaction: %v", err)
@@ -71,8 +99,8 @@ func BeginTransaction() (_ *Transaction, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Transaction{
-		tx: tx,
+	return &Tx{
+		Tx: tx,
 		db: db,
 	}, nil
 }

--- a/api/internal/svc/rpi/service_test.go
+++ b/api/internal/svc/rpi/service_test.go
@@ -1,0 +1,84 @@
+package rpi
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/emilieanthony/senzr/internal/db"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"gotest.tools/assert"
+)
+
+func createFx(data *mockData) *Server {
+	return &Server{
+		Db: &database{
+			data.CarbonDioxideData,
+		},
+	}
+}
+
+func TestRpiService_GetLatestCarbonDioxideEntry(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		timestamp := time.Date(2020, 5, 20, 20, 00, 00, 00, &time.Location{})
+		data := []*carbonDioxideEntry{
+			{
+				Id:        "1234",
+				Value:     15.0,
+				Timestamp: timestamp,
+			},
+		}
+		fx := createFx(&mockData{CarbonDioxideData: data})
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		fx.GetLatestCarbonDioxideEntry(c)
+		assert.Equal(t, 200, w.Code)
+		var got []*carbonDioxideEntry
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		assert.NilError(t, err)
+		assert.DeepEqual(
+			t,
+			got,
+			data,
+		)
+	})
+}
+
+type mockData struct {
+	CarbonDioxideData []*carbonDioxideEntry
+}
+
+type database struct {
+	CarbonDioxideData []*carbonDioxideEntry
+}
+
+type transaction struct {
+	CarbonDioxideData []*carbonDioxideEntry
+}
+
+func (d *database) BeginTransaction() (_ db.Transaction, err error) {
+	return &transaction{
+		d.CarbonDioxideData,
+	}, nil
+}
+
+func (t *transaction) Get(dest interface{}, query string, args ...interface{}) error {
+	return nil
+}
+func (t *transaction) Select(dest interface{}, query string, args ...interface{}) error {
+	pbs := dest.(*[]*carbonDioxideEntry)
+	*pbs = append(*pbs, t.CarbonDioxideData...)
+	return nil
+}
+func (t *transaction) NamedExec(query string, arg interface{}) (sql.Result, error) {
+	return nil, nil
+}
+func (t *transaction) Query(query string) (*sqlx.Rows, error) {
+	return &sqlx.Rows{}, nil
+}
+func (t *transaction) Commit() error {
+	return nil
+}


### PR DESCRIPTION
Rewrite so API can be called on the URL `https://.../api/v1/co2/latest` to get the latest CO2 data entry from the database.
Added test for it

Improvement: Add authorization so not everyone can get the data.
