### PR TITLE
add authentication middleware to api

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go/pubsub v1.10.3
+	github.com/clerkinc/clerk-sdk-go v1.0.9 // indirect
 	github.com/gin-gonic/gin v1.7.1
 	github.com/go-playground/validator/v10 v10.5.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.14.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -77,6 +77,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/clerkinc/clerk-sdk-go v1.0.9 h1:fxDdGO6B0gq8h2xpZUhNd67gdmoUvZLiKU5t0zHd9m0=
+github.com/clerkinc/clerk-sdk-go v1.0.9/go.mod h1:omhCUvAWFibd7MTNXU3y4rS1O64hQ2SCnpA951ksvwA=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
@@ -434,6 +436,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 h1:BP2bjP495BBPaBcS5rmqviTfrOkN5rO5ceKAMRZCRFc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/api/internal/config/environment.go
+++ b/api/internal/config/environment.go
@@ -5,11 +5,12 @@ import (
 )
 
 type environment struct {
-	DBHost     string `envconfig:"db_host" default:"localhost"`  // SENZR_DB_HOST
-	DBName     string `envconfig:"db_name" default:"senzr_db"`   // SENZR_DB_NAME
-	DBPort     string `envconfig:"db_port" default:"5432"`       // SENZR_DB_PORT
-	DBUser     string `envconfig:"db_user" default:"root"`       // SENZR_DB_USER
-	DBPassword string `envconfig:"db_password" default:"gbgftw"` // SENZR_DB_PASSWORD
+	DBHost     string `envconfig:"db_host" default:"localhost"`      // SENZR_DB_HOST
+	DBName     string `envconfig:"db_name" default:"senzr_db"`       // SENZR_DB_NAME
+	DBPort     string `envconfig:"db_port" default:"5432"`           // SENZR_DB_PORT
+	DBUser     string `envconfig:"db_user" default:"root"`           // SENZR_DB_USER
+	DBPassword string `envconfig:"db_password" default:"gbgftw"`     // SENZR_DB_PASSWORD
+	AuthKey    string `envconfig:"auth_key" default:"api.clerk.dev"` // SENZR_AUTH_KEY
 }
 
 func Env() (*environment, error) {

--- a/api/internal/svc/rpi/service.go
+++ b/api/internal/svc/rpi/service.go
@@ -19,8 +19,8 @@ type Server struct {
 	Db db.Database
 }
 
-func (s *Server) HelloWorld(ctx *gin.Context) {
-	ctx.String(http.StatusOK, "Hello world!")
+func (s *Server) Ping(ctx *gin.Context) {
+	ctx.String(http.StatusOK, "pong")
 }
 
 func (s *Server) GetLatestCarbonDioxideEntry(ctx *gin.Context) {


### PR DESCRIPTION
A middleware will intercept all requests and check if the request contains a valid token from Clerk.io. If not, returning http status code 401, otherwise allow request to progress to the requested endpoint.

Modified the hello world endpoint to be an unauthenticated ping endpoint to be able to test if the API is running or not.