### PR TITLE
add endpoint for retrieving co2 data over timespan

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,18 @@
+# Senzr API
+
+## Prerequisites
+
+Before running the server, install the [google cloud CLI](https://cloud.google.com/sdk/docs/install)
+for your system. Then run the following commands:
+
+1. `gcloud auth login`
+2. `gcloud beta auth application-default login`
+
+You need to Have Go 1.16 installed. Install for your system [here](https://go.dev/doc/install)
+
+## How to start
+
+_Make sure you have done the prerequisites_
+
+1. Run `make install` to install required dependencies
+2. Run `make develop` to start the server

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -42,6 +42,7 @@ func main() {
 	v1.Use(Auth(clerkClient))
 	{
 		v1.GET("/co2/latest", rpiServer.GetLatestCarbonDioxideEntry)
+		v1.GET("/co2/duration", rpiServer.GetDurationAverageCarbonDioxide)
 		v1.GET("/temperature/latest", rpiServer.GetLatestTemperatureEntry)
 		v1.GET("/humidity/latest", rpiServer.GetLatestHumidityEntry)
 	}
@@ -56,6 +57,11 @@ func main() {
 
 func Auth(client clerk.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// remove auth in debug mode
+		if gin.Mode() == "debug" {
+			c.Next()
+			return
+		}
 		session, err := client.Verification().Verify(c.Request)
 		if err != nil {
 			c.String(http.StatusUnauthorized, "Unauthorized")


### PR DESCRIPTION
This should prepare for making graphs of the CO2 data.

Calling `GET /api/v1/co2/duration?seconds=X` return a list of CO2 entries from now and X seconds back in time.

Example: `GET /api/v1/co2/duration?seconds=2592000` will return data from today and 30 days back.

Completes: https://github.com/emilieanthony/senzr/issues/41