### PR TITLE
cloudbuild speed

### DIFF
--- a/cloudbuild/deploy.yaml
+++ b/cloudbuild/deploy.yaml
@@ -3,6 +3,7 @@ steps:
     name: gcr.io/cloud-builders/npm
     entrypoint: "bash"
     dir: react-frontend
+    waitFor: ["-"]
     args:
       - "-c"
       - "make deploy"
@@ -10,6 +11,7 @@ steps:
     name: gcr.io/cloud-builders/gcloud
     entrypoint: "bash"
     dir: api
+    waitFor: ["-"]
     args:
       - "-c"
       - "make deploy"

--- a/cloudbuild/review-api.yaml
+++ b/cloudbuild/review-api.yaml
@@ -7,9 +7,11 @@ steps:
   - id: lint
     name: golang:1.16.6-buster
     dir: api
+    waitFor: ["install"]
     args: ['make', 'lint']
 
   - id: test
     name: golang:1.16.6-buster
     dir: api
+    waitFor: ["install"]
     args: ['make', 'test']

--- a/cloudbuild/review-cloud-receiver.yaml
+++ b/cloudbuild/review-cloud-receiver.yaml
@@ -7,9 +7,11 @@ steps:
   - id: lint
     name: golang:1.16.6-buster
     dir: cloud-receiver
+    waitFor: ["install"]
     args: ['make', 'lint']
 
   - id: test
     name: golang:1.16.6-buster
     dir: cloud-receiver
+    waitFor: ["install"]
     args: ['make', 'test']

--- a/cloudbuild/review-frontend.yaml
+++ b/cloudbuild/review-frontend.yaml
@@ -1,0 +1,17 @@
+steps:
+  - id: install
+    name: node:16
+    dir: react-frontend
+    args: ['yarn', 'install']
+
+  - id: lint
+    name: node:16
+    dir: react-frontend
+    waitFor: ["install"]
+    args: ['yarn', 'lint']
+
+  - id: test
+    name: node:16
+    dir: react-frontend
+    waitFor: ["install"]
+    args: ['yarn', 'test']

--- a/cloudbuild/review-rpi.yaml
+++ b/cloudbuild/review-rpi.yaml
@@ -2,14 +2,17 @@ steps:
   - id: lint
     name: golang:1.16.6-buster
     dir: rpi
+    waitFor: ["-"]
     args: ['make', 'lint']
 
   - id: test
     name: golang:1.16.6-buster
     dir: rpi
+    waitFor: ["-"]
     args: ['make', 'test']
 
   - id: build
     name: golang:1.16.6-buster
     dir: rpi
+    waitFor: ["-"]
     args: ['make', 'build']

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "PORT=8080 react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "CI=true react-scripts test --watchAll=false --passWithNoTests",
+    "lint": "eslint ./src --fix",
     "deploy": "yarn install && yarn build && yarn firebase deploy --project senzr-313218"
   },
   "dependencies": {

--- a/tools/golangci-lint/rules.mk
+++ b/tools/golangci-lint/rules.mk
@@ -16,4 +16,4 @@ endif
 golangci-lint:
 	curl -L https://github.com/golangci/golangci-lint/releases/download/v$(version)/golangci-lint-$(version)-$(os)-$(arch).tar.gz | tar xvzf - -C $(path)/
 	chmod 755 $(path)/golangci-lint-$(version)-$(os)-$(arch)/golangci-lint
-	./$(path)/golangci-lint-$(version)-$(os)-$(arch)/golangci-lint run
+	./$(path)/golangci-lint-$(version)-$(os)-$(arch)/golangci-lint run --timeout 5m


### PR DESCRIPTION
- parallelize CI steps (speeds up the CI by letting all steps run in parallel and not in a sequence)
- add review step for frontend (running tests and linting)
