### PR TITLE
Fix daily avg

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -42,7 +42,7 @@ func main() {
 	v1.Use(Auth(clerkClient))
 	{
 		v1.GET("/co2/latest", rpiServer.GetLatestCarbonDioxideEntry)
-		v1.GET("/co2/duration", rpiServer.GetDurationAverageCarbonDioxide)
+		v1.GET("/co2/duration", rpiServer.GetDurationCarbonDioxide)
 		v1.GET("/co2/daily-average", rpiServer.GetDailyAverageCarbonDioxide)
 	}
 

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -44,8 +44,6 @@ func main() {
 		v1.GET("/co2/latest", rpiServer.GetLatestCarbonDioxideEntry)
 		v1.GET("/co2/duration", rpiServer.GetDurationAverageCarbonDioxide)
 		v1.GET("/co2/daily-average", rpiServer.GetDailyAverageCarbonDioxide)
-		v1.GET("/temperature/latest", rpiServer.GetLatestTemperatureEntry)
-		v1.GET("/humidity/latest", rpiServer.GetLatestHumidityEntry)
 	}
 
 	// start app

--- a/api/internal/svc/rpi/service.go
+++ b/api/internal/svc/rpi/service.go
@@ -30,9 +30,9 @@ type dailyAverage struct {
 	Value float64 `json:"value"`
 }
 
-func (s *Server) GetDailyAverageCarbonDioxide (ctx *gin.Context){
+func (s *Server) GetDailyAverageCarbonDioxide(ctx *gin.Context) {
 	client, err := db.NewClient(ctx)
-	defer func(){
+	defer func() {
 		client.Close()
 	}()
 	if err != nil {
@@ -67,7 +67,7 @@ func (s *Server) GetDailyAverageCarbonDioxide (ctx *gin.Context){
 		totalRecordsCount = 1
 	}
 	average := dailyAverage{
-		Value: float64(totalCo2)/float64(totalRecordsCount),
+		Value: float64(totalCo2) / float64(totalRecordsCount),
 	}
 	ctx.JSON(http.StatusOK, average)
 }
@@ -90,54 +90,6 @@ func (s *Server) GetLatestCarbonDioxideEntry(ctx *gin.Context) {
 	var data *entry
 	if err := document.DataTo(&data); err != nil {
 		ctx.String(http.StatusInternalServerError, "GetLatestCarbonDioxideEntry: reading from database")
-		return
-	}
-	data.Id = document.Ref.ID
-	ctx.JSON(http.StatusOK, data)
-}
-
-func (s *Server) GetLatestTemperatureEntry(ctx *gin.Context) {
-	client, err := db.NewClient(ctx)
-	defer func() {
-		client.Close()
-	}()
-	if err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestTemperatureEntry: creating client")
-		return
-	}
-	query := client.Collection(db.CollectionTemperature).OrderBy("created_at", firestore.Desc).Limit(1)
-	document, err := query.Documents(ctx).Next()
-	if err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestTemperatureEntry: getting from database")
-		return
-	}
-	var data *entry
-	if err := document.DataTo(&data); err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestTemperatureEntry: reading from database")
-		return
-	}
-	data.Id = document.Ref.ID
-	ctx.JSON(http.StatusOK, data)
-}
-
-func (s *Server) GetLatestHumidityEntry(ctx *gin.Context) {
-	client, err := db.NewClient(ctx)
-	defer func() {
-		client.Close()
-	}()
-	if err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestHumidityEntry: creating client")
-		return
-	}
-	query := client.Collection(db.CollectionHumidity).OrderBy("created_at", firestore.Desc).Limit(1)
-	document, err := query.Documents(ctx).Next()
-	if err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestHumidityEntry: getting from database")
-		return
-	}
-	var data *entry
-	if err := document.DataTo(&data); err != nil {
-		ctx.String(http.StatusInternalServerError, "GetLatestHumidityEntry: reading from database")
 		return
 	}
 	data.Id = document.Ref.ID

--- a/api/internal/svc/rpi/service.go
+++ b/api/internal/svc/rpi/service.go
@@ -96,10 +96,10 @@ func (s *Server) GetLatestCarbonDioxideEntry(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, data)
 }
 
-// GetDurationAverageCarbonDioxide takes a query parameter "seconds" that is the duration from the current time
-// to calculate a CO2 average over.
+// GetDurationCarbonDioxide takes a query parameter "seconds" that is the duration from the current time
+// to get CO2 data over.
 // Defaults to "43200" (12h) if not set. Max is 2592000 (30 days).
-func (s *Server) GetDurationAverageCarbonDioxide(ctx *gin.Context) {
+func (s *Server) GetDurationCarbonDioxide(ctx *gin.Context) {
 	const maxDurationSeconds = 2592000
 	durationParam := ctx.DefaultQuery("seconds", "43200")
 	durationSeconds, err := strconv.Atoi(durationParam)

--- a/rpi/Makefile
+++ b/rpi/Makefile
@@ -35,6 +35,9 @@ install:
 test:
 	go test ./...
 
+run:
+	nohup build/rpi &
+
 lint: golangci-lint
 
 build: build-rpi install


### PR DESCRIPTION
- remove unused endpoints (as we no longer use them we can remove them)
- rename GetDurationAverageCarbonDioxide to GetDurationCarbonDioxide (it was not calculating average, so rename it to what it does. E.g. returning an array of data for an interval)
- fix GetDailyAverageCarbonDioxide query (should now be working as intended)
- add run target that should run on the rpi (this is the command you run on the Raspberry Pi to start the application. Added it to the documentation so we dont forget how to actually run it)